### PR TITLE
feat: add pi prompt templates

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -53,6 +53,7 @@ homebrew:
 
 npm:
   packages:
+    - "@earendil-works/pi-coding-agent"
     - vscode-langservers-extracted
 
 commands:
@@ -70,6 +71,14 @@ rules:
     dst: "$HOME/.claude/commands/review.md"
   - src: "data/claude/settings.json"
     dst: "$HOME/.claude/settings.json"
+
+  # pi
+  - src: "data/pi/prompts/commit.md"
+    dst: "$HOME/.pi/agent/prompts/commit.md"
+  - src: "data/pi/prompts/review.md"
+    dst: "$HOME/.pi/agent/prompts/review.md"
+  - src: "data/pi/prompts/review-branch.md"
+    dst: "$HOME/.pi/agent/prompts/review-branch.md"
 
   # fish
   - src: "data/fish/config.fish"

--- a/data/pi/prompts/commit.md
+++ b/data/pi/prompts/commit.md
@@ -1,0 +1,54 @@
+---
+description: Commit the current changes
+argument-hint: "[instructions]"
+---
+
+Commit the current changes cleanly. Additional user instructions: ${ARGUMENTS:-none}
+
+Workflow:
+
+1. Inspect repository state:
+   - `git status --short --branch`
+   - `git diff`
+   - `git diff --cached`
+   - `git log --oneline -10`
+
+2. Determine the primary branch:
+   - Prefer the upstream default branch from `git symbolic-ref refs/remotes/origin/HEAD` when available
+   - Otherwise use `main` if it exists
+   - Otherwise use `master` if it exists
+
+3. Review the changes before committing:
+   - Understand the intent of the diff
+   - Watch for secrets, accidental debug code, generated junk, or unrelated changes
+   - If changes look unsafe or unrelated, stop and ask before committing
+
+4. Create or confirm the working branch before staging:
+   - If the current branch is the primary branch, create a new appropriately named branch before staging or committing
+   - If the current branch is already a feature/topic branch, keep using it unless the user asked otherwise
+   - Choose a concise branch name that reflects the change
+
+5. Stage and commit:
+   - Stage the intended changes
+   - Write a conventional commit message
+   - Keep the subject under 72 characters
+   - Add a body only when helpful
+   - Match the tone and style of recent commits
+
+6. Push the commit:
+   - Push the branch to origin, setting upstream when needed
+
+7. Ask about creating a pull request:
+   - After the commit has been pushed, ask the user whether they want a pull request created
+   - Do not create a pull request unless the user confirms
+   - If confirmed, create a pull request against the primary branch using `gh pr create` when available
+   - Write a concise PR title and body summarizing changes and validation
+
+8. Final response:
+   - Commit SHA and message
+   - Branch name
+   - Push result
+   - PR URL, if created
+   - Validation run and result
+   - Any notable caveats
+

--- a/data/pi/prompts/review-branch.md
+++ b/data/pi/prompts/review-branch.md
@@ -1,0 +1,58 @@
+---
+description: Review changes on the current branch against the primary branch
+argument-hint: "[focus]"
+---
+
+Review all changes on the current branch compared to the repository's primary branch. Optional focus from the user: ${ARGUMENTS:-none}
+
+Workflow:
+
+1. Determine the primary branch:
+   - Prefer the upstream default branch from `git symbolic-ref refs/remotes/origin/HEAD` when available
+   - Otherwise use `main` if it exists
+   - Otherwise use `master` if it exists
+
+2. Inspect the change set:
+   - `git status --short --branch`
+   - `git merge-base HEAD <primary-branch>`
+   - `git diff --stat <primary-branch>...HEAD`
+   - `git diff --name-status <primary-branch>...HEAD`
+   - `git diff <primary-branch>...HEAD`
+   - Recent context when helpful: `git log --oneline --decorate -10`
+
+3. Understand the intent before judging:
+   - Summarize what the change appears to do
+   - Identify the riskiest files or paths first
+   - Read surrounding code for non-trivial changes instead of relying only on the diff
+   - Inspect relevant tests, call sites, config, migrations, or docs when they affect correctness
+
+Review priorities, in order:
+
+1. **Correctness and regressions** — Broken behavior, invalid assumptions, missed call sites, changed contracts, bad error handling, race conditions, off-by-one mistakes, nil/null handling, type issues
+2. **Security and data safety** — Injection, auth/authz mistakes, unsafe filesystem/network behavior, secret leakage, destructive operations, unsafe defaults
+3. **Edge cases and reliability** — Empty inputs, large inputs, concurrency, retries, timeouts, partial failures, platform differences
+4. **Tests and validation** — Missing or weak tests for important behavior, snapshots needing updates, test assertions that do not prove the behavior
+5. **Maintainability** — Unnecessary complexity, duplication, dead code, confusing names, avoidable abstractions
+
+Guidelines:
+
+- Focus on actionable issues that the author should consider before merging
+- Do not nitpick formatting or style unless it affects readability, correctness, or consistency with nearby code
+- Do not invent issues; verify claims against the code when possible
+- Prefer fewer, higher-confidence findings over a long speculative list
+- If a finding depends on uncertainty, say what you are assuming and how to verify it
+- Include positive notes only briefly, after findings or when there are no findings
+
+Output format:
+
+1. Start with a short summary of the change and overall risk level: **low**, **medium**, or **high**
+2. Then list findings by severity:
+   - 🔴 **Critical** — Bugs, security issues, or regressions that must be fixed
+   - 🟡 **Warning** — Likely issues or important gaps worth addressing
+   - 🟢 **Suggestion** — Simplifications or improvements, not blocking
+3. For each finding include:
+   - File and line/range when possible
+   - What is wrong
+   - Why it matters
+   - A concrete suggested fix
+4. If there are no findings, say that the changes look good and mention any validation gaps you noticed

--- a/data/pi/prompts/review.md
+++ b/data/pi/prompts/review.md
@@ -1,0 +1,56 @@
+---
+description: Review unstaged changes in the working tree
+argument-hint: "[focus]"
+---
+
+Review the unstaged changes in the current working tree. Optional focus from the user: ${ARGUMENTS:-none}
+
+Workflow:
+
+1. Inspect the working tree:
+   - `git status --short --branch`
+   - `git diff --stat`
+   - `git diff --name-status`
+   - `git diff`
+
+2. Scope the review:
+   - Focus on unstaged tracked-file changes from `git diff`
+   - Note staged changes separately if `git status` shows any, but do not review them unless needed for context
+   - Note untracked files separately; read them only if they appear directly relevant to the unstaged changes
+
+3. Understand the intent before judging:
+   - Summarize what the unstaged change appears to do
+   - Identify the riskiest files or paths first
+   - Read surrounding code for non-trivial changes instead of relying only on the diff
+   - Inspect relevant tests, call sites, config, migrations, or docs when they affect correctness
+
+Review priorities, in order:
+
+1. **Correctness and regressions** — Broken behavior, invalid assumptions, missed call sites, changed contracts, bad error handling, race conditions, off-by-one mistakes, nil/null handling, type issues
+2. **Security and data safety** — Injection, auth/authz mistakes, unsafe filesystem/network behavior, secret leakage, destructive operations, unsafe defaults
+3. **Edge cases and reliability** — Empty inputs, large inputs, concurrency, retries, timeouts, partial failures, platform differences
+4. **Tests and validation** — Missing or weak tests for important behavior, snapshots needing updates, test assertions that do not prove the behavior
+5. **Maintainability** — Unnecessary complexity, duplication, dead code, confusing names, avoidable abstractions
+
+Guidelines:
+
+- Focus on actionable issues that should be addressed before staging or committing
+- Do not nitpick formatting or style unless it affects readability, correctness, or consistency with nearby code
+- Do not invent issues; verify claims against the code when possible
+- Prefer fewer, higher-confidence findings over a long speculative list
+- If a finding depends on uncertainty, say what you are assuming and how to verify it
+- Include positive notes only briefly, after findings or when there are no findings
+
+Output format:
+
+1. Start with a short summary of the unstaged change and overall risk level: **low**, **medium**, or **high**
+2. Then list findings by severity:
+   - 🔴 **Critical** — Bugs, security issues, or regressions that must be fixed
+   - 🟡 **Warning** — Likely issues or important gaps worth addressing
+   - 🟢 **Suggestion** — Simplifications or improvements, not blocking
+3. For each finding include:
+   - File and line/range when possible
+   - What is wrong
+   - Why it matters
+   - A concrete suggested fix
+4. If there are no findings, say that the unstaged changes look good and mention any validation gaps you noticed

--- a/src/main.rs
+++ b/src/main.rs
@@ -99,6 +99,7 @@ fn process_npm(config: &Npm) -> Result<()> {
         "install".to_owned(),
         "--quiet".to_owned(),
         "--global".to_owned(),
+        "--ignore-scripts".to_owned(),
         "--no-fund".to_owned(),
         "--no-update-notifier".to_owned(),
     ];


### PR DESCRIPTION
## Summary
- install pi via the global npm package list
- add pi prompt templates for commit, working-tree review, and branch review workflows
- install npm packages with --ignore-scripts

## Validation
- ruby -ryaml -e 'YAML.load_file("config.yaml"); puts "config.yaml ok"'
- cargo fmt --check
- cargo check --quiet