### PR TITLE
fix: format long rate-limit durations

### DIFF
--- a/data/pi/extensions/rate-limits.ts
+++ b/data/pi/extensions/rate-limits.ts
@@ -53,8 +53,10 @@ const formatReset = (window: RateLimitWindow | undefined | null) => {
 
 const formatDuration = (seconds: number | undefined) => {
   if (typeof seconds !== "number") return undefined;
-  const hours = Math.floor(seconds / 3600);
+  const days = Math.floor(seconds / 86400);
+  const hours = Math.floor((seconds % 86400) / 3600);
   const minutes = Math.floor((seconds % 3600) / 60);
+  if (days > 0) return `${days}d ${hours}h ${minutes}m`;
   if (hours > 0) return `${hours}h ${minutes}m`;
   return `${minutes}m`;
 };


### PR DESCRIPTION
## Summary
- Format rate-limit reset durations over 24 hours as days, hours, and minutes

## Validation
- npm run check