### PR TITLE
style: remove emoji from pi review prompt severity labels

### DIFF
--- a/data/pi/prompts/commit.md
+++ b/data/pi/prompts/commit.md
@@ -49,6 +49,6 @@ Workflow:
    - Branch name
    - Push result
    - PR URL, if created
-   - Validation run and result
+   - Any validation run and result
    - Any notable caveats
 

--- a/data/pi/prompts/review-branch.md
+++ b/data/pi/prompts/review-branch.md
@@ -47,9 +47,9 @@ Output format:
 
 1. Start with a short summary of the change and overall risk level: **low**, **medium**, or **high**
 2. Then list findings by severity:
-   - 🔴 **Critical** — Bugs, security issues, or regressions that must be fixed
-   - 🟡 **Warning** — Likely issues or important gaps worth addressing
-   - 🟢 **Suggestion** — Simplifications or improvements, not blocking
+   - **Critical** — Bugs, security issues, or regressions that must be fixed
+   - **Warning** — Likely issues or important gaps worth addressing
+   - **Suggestion** — Simplifications or improvements, not blocking
 3. For each finding include:
    - File and line/range when possible
    - What is wrong

--- a/data/pi/prompts/review.md
+++ b/data/pi/prompts/review.md
@@ -45,9 +45,9 @@ Output format:
 
 1. Start with a short summary of the unstaged change and overall risk level: **low**, **medium**, or **high**
 2. Then list findings by severity:
-   - 🔴 **Critical** — Bugs, security issues, or regressions that must be fixed
-   - 🟡 **Warning** — Likely issues or important gaps worth addressing
-   - 🟢 **Suggestion** — Simplifications or improvements, not blocking
+   - **Critical** — Bugs, security issues, or regressions that must be fixed
+   - **Warning** — Likely issues or important gaps worth addressing
+   - **Suggestion** — Simplifications or improvements, not blocking
 3. For each finding include:
    - File and line/range when possible
    - What is wrong


### PR DESCRIPTION
## Summary
Removes emoji (🔴 🟡 🟢) from severity labels in pi review prompt templates, and adjusts a wording in the commit prompt.

## Changes
- **review.md / review-branch.md** — Replaced emoji-prefixed severity labels with plain text equivalents
- **commit.md** — Changed "Validation run and result" to "Any validation run and result" for accuracy

## Validation
- Diff reviewed — no functional changes, formatting/style only