### PR TITLE
feat: enable GFM output for web reader

### DIFF
--- a/data/pi/extensions/web-search/index.ts
+++ b/data/pi/extensions/web-search/index.ts
@@ -2,6 +2,7 @@ import { Readability } from "@mozilla/readability";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { JSDOM } from "jsdom";
 import TurndownService from "turndown";
+import { gfm } from "@joplin/turndown-plugin-gfm";
 import { Type } from "typebox";
 
 type SearchResult = {
@@ -228,6 +229,7 @@ async function readUrl(url: string, signal?: AbortSignal): Promise<ReadUrlResult
     element.remove();
   }
   const turndown = new TurndownService({ codeBlockStyle: "fenced", headingStyle: "atx", bulletListMarker: "-" });
+  turndown.use(gfm);
   const markdown = turndown.turndown(articleDom.window.document.body.innerHTML).trim();
   articleDom.window.close();
 

--- a/data/pi/extensions/web-search/package-lock.json
+++ b/data/pi/extensions/web-search/package-lock.json
@@ -8,6 +8,7 @@
       "name": "pi-web-search-extension",
       "version": "0.0.0",
       "dependencies": {
+        "@joplin/turndown-plugin-gfm": "^1.0.67",
         "@mozilla/readability": "^0.6.0",
         "jsdom": "^29.1.1",
         "turndown": "^7.2.4",
@@ -223,6 +224,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@joplin/turndown-plugin-gfm": {
+      "version": "1.0.67",
+      "resolved": "https://registry.npmjs.org/@joplin/turndown-plugin-gfm/-/turndown-plugin-gfm-1.0.67.tgz",
+      "integrity": "sha512-FZfW5EZfidhzd1IaY1uxHnIZPTVOxAdleMZ4/1U6Nt5b7+Qj5JThDnaIomuJtetnUBzuRNbe9FWMuqD4B3dlWA==",
+      "license": "MIT"
     },
     "node_modules/@mixmark-io/domino": {
       "version": "2.2.0",

--- a/data/pi/extensions/web-search/package.json
+++ b/data/pi/extensions/web-search/package.json
@@ -7,6 +7,7 @@
     "extensions": ["./index.ts"]
   },
   "dependencies": {
+    "@joplin/turndown-plugin-gfm": "^1.0.67",
     "@mozilla/readability": "^0.6.0",
     "jsdom": "^29.1.1",
     "turndown": "^7.2.4",


### PR DESCRIPTION
## Summary
- add @joplin/turndown-plugin-gfm to the pi web-search extension
- enable GFM conversion for read_url Markdown output

## Validation
- ran a Node import/conversion check for the Joplin GFM plugin