### PR TITLE
refactor: rename pi web tools extension

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -58,7 +58,7 @@ npm:
 
 commands:
   - "go install github.com/ryanfowler/gitlink@latest"
-  - "npm install --prefix data/pi/extensions/web-search --quiet --ignore-scripts --no-fund --no-update-notifier"
+  - "npm install --prefix data/pi/extensions/web-tools --quiet --ignore-scripts --no-fund --no-update-notifier"
 
 rules:
   # alacritty
@@ -76,8 +76,8 @@ rules:
   # pi
   - src: "data/pi/extensions/rate-limits.ts"
     dst: "$HOME/.pi/agent/extensions/rate-limits.ts"
-  - src: "data/pi/extensions/web-search"
-    dst: "$HOME/.pi/agent/extensions/web-search"
+  - src: "data/pi/extensions/web-tools"
+    dst: "$HOME/.pi/agent/extensions/web-tools"
   - src: "data/pi/prompts/commit.md"
     dst: "$HOME/.pi/agent/prompts/commit.md"
   - src: "data/pi/prompts/review.md"

--- a/data/pi/extensions/web-search/README.md
+++ b/data/pi/extensions/web-search/README.md
@@ -1,9 +1,0 @@
-# pi web-search extension
-
-Project-local source for a pi extension that registers two composable tools:
-
-- `web_search` — DuckDuckGo HTML search results only
-- `read_url` — fetch one public HTML page, extract with Readability, convert to Markdown
-
-The dotfiles installer installs this extension's npm dependencies, then links this directory to `~/.pi/agent/extensions/web-search`.
-The implementation lives in `index.ts`; dependencies are declared and locked in this directory.

--- a/data/pi/extensions/web-tools/README.md
+++ b/data/pi/extensions/web-tools/README.md
@@ -1,0 +1,9 @@
+# pi web-tools extension
+
+Project-local source for a pi extension that registers two composable tools:
+
+- `web_search` — search results only
+- `web_fetch` — fetch one public HTML page, extract with Readability, convert to Markdown
+
+The dotfiles installer installs this extension's npm dependencies, then links this directory to `~/.pi/agent/extensions/web-tools`.
+The implementation lives in `index.ts`; dependencies are declared and locked in this directory.

--- a/data/pi/extensions/web-tools/index.ts
+++ b/data/pi/extensions/web-tools/index.ts
@@ -20,7 +20,7 @@ type ReadUrlResult = {
 };
 
 const DDG_SEARCH_URL = "https://html.duckduckgo.com/html/";
-const USER_AGENT = "pi-web-search/0.1 (+https://github.com/ryanfowler/dotfiles)";
+const USER_AGENT = "pi-web-tools/0.1 (+https://github.com/ryanfowler/dotfiles)";
 const MAX_BYTES = 5 * 1024 * 1024;
 const TIMEOUT_MS = 10_000;
 const MAX_REDIRECTS = 5;
@@ -155,7 +155,10 @@ async function readResponseBytes(response: Response, signal?: AbortSignal): Prom
     if (done) break;
     if (!value) continue;
     received += value.byteLength;
-    if (received > MAX_BYTES) throw new Error(`response exceeds ${MAX_BYTES} bytes`);
+    if (received > MAX_BYTES) {
+      await reader.cancel().catch(() => undefined);
+      throw new Error(`response exceeds ${MAX_BYTES} bytes`);
+    }
     chunks.push(value);
   }
 
@@ -246,8 +249,8 @@ export default function (pi: ExtensionAPI) {
   pi.registerTool({
     name: "web_search",
     label: "Web Search",
-    description: "Search DuckDuckGo HTML and return search results without fetching pages.",
-    promptSnippet: "Search DuckDuckGo for public web pages; returns titles, URLs, and snippets only.",
+    description: "Search the web and return results without fetching pages.",
+    promptSnippet: "Search public web pages; returns titles, URLs, and snippets only.",
     promptGuidelines: ["Use web_search for web discovery when you need relevant public URLs before reading pages."],
     parameters: {
       type: "object",
@@ -263,11 +266,11 @@ export default function (pi: ExtensionAPI) {
   });
 
   pi.registerTool({
-    name: "read_url",
-    label: "Read URL",
+    name: "web_fetch",
+    label: "Web Fetch",
     description: "Fetch a public HTML page, extract the main article with Readability, and return Markdown.",
     promptSnippet: "Read a specific public URL and return cleaned Markdown article content.",
-    promptGuidelines: ["Use read_url when the user provides a URL or when detailed source content is needed from a known URL."],
+    promptGuidelines: ["Use web_fetch when the user provides a URL or when detailed source content is needed from a known URL."],
     parameters: {
       type: "object",
       properties: {

--- a/data/pi/extensions/web-tools/package-lock.json
+++ b/data/pi/extensions/web-tools/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "pi-web-search-extension",
+  "name": "pi-web-tools-extension",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "pi-web-search-extension",
+      "name": "pi-web-tools-extension",
       "version": "0.0.0",
       "dependencies": {
         "@joplin/turndown-plugin-gfm": "^1.0.67",

--- a/data/pi/extensions/web-tools/package.json
+++ b/data/pi/extensions/web-tools/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "pi-web-search-extension",
+  "name": "pi-web-tools-extension",
   "version": "0.0.0",
   "private": true,
   "type": "module",

--- a/plans/pi-web-extension.md
+++ b/plans/pi-web-extension.md
@@ -39,7 +39,7 @@ Output:
 }
 ```
 
-### `read_url`
+### `web_fetch`
 
 Downloads one HTML page, extracts the main article, and returns Markdown.
 
@@ -68,7 +68,7 @@ Output:
 
 - No browser automation.
 - No JavaScript rendering.
-- No combined `search_and_read` tool; agents can compose `web_search` and `read_url` explicitly.
+- No combined `search_and_fetch` tool; agents can compose `web_search` and `web_fetch` explicitly.
 - No cache or provider abstraction until the basic extension proves useful.
 
 ## Pipeline
@@ -77,7 +77,7 @@ Output:
 web_search:
 DuckDuckGo HTML -> parse results -> title/url/snippet
 
-read_url:
+web_fetch:
 URL -> fetch HTML -> Readability -> Turndown -> Markdown
 ```
 
@@ -89,12 +89,12 @@ Keep the implementation bounded:
 - cap response size
 - follow a small number of redirects
 - reject non-HTTP(S) schemes
-- only accept HTML-ish content types for `read_url`
+- only accept HTML-ish content types for `web_fetch`
 - honor cancellation signals
 
 ## Agent Usage Guidance
 
 - Use `web_search` when discovering relevant public URLs.
-- Use `read_url` when detailed source content is needed from a known URL.
+- Use `web_fetch` when detailed source content is needed from a known URL.
 - Prefer reading only the minimum number of pages needed to answer the question.
 - Always preserve source URLs in returned data so downstream answers can cite them.


### PR DESCRIPTION
## Summary
- rename the Pi extension from `web-search` to `web-tools`
- rename `read_url` to `web_fetch` and simplify web-search metadata
- cancel response readers when the size limit is exceeded

## Validation
- `pi --no-extensions -e ./data/pi/extensions/web-tools --help`
- `npm install --prefix data/pi/extensions/web-tools --package-lock-only --ignore-scripts --no-fund --no-update-notifier --offline`