### PR TITLE
feat: support content types in web fetch

### DIFF
--- a/data/pi/extensions/web-tools/README.md
+++ b/data/pi/extensions/web-tools/README.md
@@ -3,7 +3,20 @@
 Project-local source for a pi extension that registers two composable tools:
 
 - `web_search` — search results only
-- `web_fetch` — fetch one public HTML page, extract with Readability, convert to Markdown
+- `web_fetch` — fetch one public URL with content-type-aware handling
+
+`web_fetch` returns a uniform `content` field plus response metadata:
+
+- HTML is extracted with Readability and converted to Markdown.
+- Markdown is passed through unchanged.
+- Other textual formats (including JSON, XML, YAML, JavaScript, and SVG) are passed through as text.
+- Binary formats are passed through as base64.
+
+`contentType` preserves the server's Content-Type header (or defaults to `application/octet-stream`), while `contentFormat` describes the returned representation: `markdown`, `text`, or `base64`. `url` is the final URL after redirects and `bytes` is the downloaded size. HTML results also include article metadata such as `title`, `excerpt`, and `byline` when available.
+
+Only public HTTP(S) destinations are allowed. Hostnames are resolved and checked before the initial request and every redirect; loopback, private, link-local, reserved, and multicast addresses are rejected.
+
+Run the automated tests with `npm test --prefix data/pi/extensions/web-tools`.
 
 The dotfiles installer installs this extension's npm dependencies, then links this directory to `~/.pi/agent/extensions/web-tools`.
 The implementation lives in `index.ts`; dependencies are declared and locked in this directory.

--- a/data/pi/extensions/web-tools/index.test.mjs
+++ b/data/pi/extensions/web-tools/index.test.mjs
@@ -1,0 +1,178 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readUrl } from "./index.ts";
+
+const PUBLIC_BASE = "https://8.8.8.8";
+const originalFetch = globalThis.fetch;
+
+function response(body, contentType, init = {}) {
+  const headers = new Headers(init.headers);
+  if (contentType) headers.set("Content-Type", contentType);
+  return new Response(body, { ...init, headers });
+}
+
+async function withFetch(fetchImpl, callback) {
+  globalThis.fetch = fetchImpl;
+  try {
+    return await callback();
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+}
+
+test("converts mixed-case, parameterized HTML to Markdown and retains metadata", async () => {
+  const html = `<!doctype html><html><head><title>Test article</title></head><body><main>
+    <h1>Hello</h1><p>This article has enough meaningful text for Readability to extract the main content.</p>
+  </main></body></html>`;
+
+  await withFetch(async () => response(html, 'TeXt/HTML; Charset="utf-8"'), async () => {
+    const result = await readUrl(`${PUBLIC_BASE}/article`);
+    assert.equal(result.contentType, 'TeXt/HTML; Charset="utf-8"');
+    assert.equal(result.contentFormat, "markdown");
+    assert.match(result.content, /# Hello/);
+    assert.equal(result.title, "Test article");
+    assert.equal(result.bytes, Buffer.byteLength(html));
+  });
+});
+
+test("passes Markdown through using a quoted, mixed-case charset parameter", async () => {
+  const markdown = "# Héllo\n\nExact markdown.\n";
+  const encoded = Buffer.from(markdown, "utf16le");
+
+  await withFetch(async () => response(encoded, 'TeXt/MaRkDoWn; version=1; CHARSET="utf-16le"'), async () => {
+    const result = await readUrl(`${PUBLIC_BASE}/readme.md`);
+    assert.equal(result.contentFormat, "markdown");
+    assert.equal(result.content, markdown);
+  });
+});
+
+test("handles JSON/XML suffix MIME types as text", async () => {
+  const bodies = [
+    ["application/problem+json", '{"error":"nope"}'],
+    ["application/atom+xml; charset=utf-8", "<feed><title>News</title></feed>"],
+  ];
+  let index = 0;
+
+  await withFetch(async () => response(bodies[index][1], bodies[index++][0]), async () => {
+    for (const [contentType, content] of bodies) {
+      const result = await readUrl(`${PUBLIC_BASE}/${index}`);
+      assert.equal(result.contentType, contentType);
+      assert.equal(result.contentFormat, "text");
+      assert.equal(result.content, content);
+    }
+  });
+});
+
+test("defaults missing charsets to UTF-8 and falls back from unsupported charsets", async () => {
+  const content = "héllo";
+  let call = 0;
+
+  await withFetch(
+    async () => response(Buffer.from(content), call++ === 0 ? "text/plain" : "text/plain; charset=not-a-charset"),
+    async () => {
+      assert.equal((await readUrl(`${PUBLIC_BASE}/missing`)).content, content);
+      assert.equal((await readUrl(`${PUBLIC_BASE}/unsupported`)).content, content);
+    },
+  );
+});
+
+test("returns binary and missing Content-Type responses as base64", async () => {
+  const bytes = Buffer.from([0, 1, 2, 255]);
+  let call = 0;
+
+  await withFetch(async () => response(bytes, call++ === 0 ? "application/pdf" : undefined), async () => {
+    const binary = await readUrl(`${PUBLIC_BASE}/file.pdf`);
+    assert.equal(binary.contentFormat, "base64");
+    assert.equal(binary.content, "AAEC/w==");
+
+    const missing = await readUrl(`${PUBLIC_BASE}/unknown`);
+    assert.equal(missing.contentType, "application/octet-stream");
+    assert.equal(missing.contentFormat, "base64");
+  });
+});
+
+test("follows relative redirects and reports the final URL and Content-Type", async () => {
+  const seen = [];
+  await withFetch(async (url) => {
+    seen.push(url);
+    if (seen.length === 1) return response(null, undefined, { status: 302, headers: { Location: "/final" } });
+    return response("done", "text/plain");
+  }, async () => {
+    const result = await readUrl(`${PUBLIC_BASE}/start`);
+    assert.deepEqual(seen, [`${PUBLIC_BASE}/start`, `${PUBLIC_BASE}/final`]);
+    assert.equal(result.url, `${PUBLIC_BASE}/final`);
+    assert.equal(result.contentType, "text/plain");
+    assert.equal(result.content, "done");
+  });
+});
+
+test("rejects redirects to private addresses before the redirected fetch", async () => {
+  let calls = 0;
+  await withFetch(async () => {
+    calls++;
+    return response(null, undefined, { status: 302, headers: { Location: "http://127.0.0.1/secret" } });
+  }, async () => {
+    await assert.rejects(readUrl(`${PUBLIC_BASE}/start`), /non-public address/);
+    assert.equal(calls, 1);
+  });
+});
+
+test("rejects redirect chains beyond the configured limit", async () => {
+  let calls = 0;
+  await withFetch(async () => {
+    calls++;
+    return response(null, undefined, { status: 302, headers: { Location: `/redirect-${calls}` } });
+  }, async () => {
+    await assert.rejects(readUrl(`${PUBLIC_BASE}/start`), /too many redirects/);
+    assert.equal(calls, 6);
+  });
+});
+
+test("rejects responses exceeding MAX_BYTES", async () => {
+  const oversized = new Uint8Array(5 * 1024 * 1024 + 1);
+  await withFetch(async () => response(oversized, "text/plain"), async () => {
+    await assert.rejects(readUrl(`${PUBLIC_BASE}/large`), /response exceeds 5242880 bytes/);
+  });
+});
+
+test("honors caller cancellation", async () => {
+  await withFetch((_url, { signal }) => new Promise((_resolve, reject) => {
+    if (signal.aborted) {
+      reject(signal.reason);
+      return;
+    }
+    signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+  }), async () => {
+    const controller = new AbortController();
+    const pending = readUrl(`${PUBLIC_BASE}/slow`, controller.signal);
+    controller.abort(new Error("cancelled by test"));
+    await assert.rejects(pending, /cancelled by test/);
+  });
+});
+
+test("times out stalled fetches", async () => {
+  await withFetch((_url, { signal }) => new Promise((_resolve, reject) => {
+    signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+  }), async () => {
+    await assert.rejects(readUrl(`${PUBLIC_BASE}/slow`, undefined, { timeoutMs: 5 }), /fetch timeout/);
+  });
+});
+
+test("rejects private literal and resolved addresses before fetching", async () => {
+  let called = false;
+  await withFetch(async () => {
+    called = true;
+    return response("secret", "text/plain");
+  }, async () => {
+    for (const url of [
+      "http://127.0.0.1/",
+      "http://10.0.0.1/",
+      "http://[::1]/",
+      "http://[::ffff:127.0.0.1]/",
+      "http://localhost/",
+    ]) {
+      await assert.rejects(readUrl(url), /non-public address/);
+    }
+    assert.equal(called, false);
+  });
+});

--- a/data/pi/extensions/web-tools/index.ts
+++ b/data/pi/extensions/web-tools/index.ts
@@ -1,5 +1,7 @@
 import { Readability } from "@mozilla/readability";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { lookup } from "node:dns/promises";
+import { BlockList, isIP } from "node:net";
 import { JSDOM } from "jsdom";
 import TurndownService from "turndown";
 import { gfm } from "@joplin/turndown-plugin-gfm";
@@ -11,12 +13,28 @@ type SearchResult = {
 };
 
 type ReadUrlResult = {
-  title: string;
   url: string;
+  contentType: string;
+  contentFormat: "markdown" | "text" | "base64";
+  content: string;
+  bytes: number;
+  title?: string;
   excerpt?: string | null;
   byline?: string | null;
-  markdown: string;
-  length: number;
+  length?: number;
+};
+
+type FetchedResource = {
+  url: string;
+  contentType: string;
+  mediaType: string;
+  charset?: string;
+  bytes: Uint8Array;
+};
+
+type ReadUrlOptions = {
+  maxBytes?: number;
+  timeoutMs?: number;
 };
 
 const DDG_SEARCH_URL = "https://html.duckduckgo.com/html/";
@@ -24,6 +42,37 @@ const USER_AGENT = "pi-web-tools/0.1 (+https://github.com/ryanfowler/dotfiles)";
 const MAX_BYTES = 5 * 1024 * 1024;
 const TIMEOUT_MS = 10_000;
 const MAX_REDIRECTS = 5;
+
+const NON_PUBLIC_ADDRESSES = new BlockList();
+for (const [network, prefix] of [
+  ["0.0.0.0", 8],
+  ["10.0.0.0", 8],
+  ["100.64.0.0", 10],
+  ["127.0.0.0", 8],
+  ["169.254.0.0", 16],
+  ["172.16.0.0", 12],
+  ["192.0.0.0", 24],
+  ["192.0.2.0", 24],
+  ["192.168.0.0", 16],
+  ["198.18.0.0", 15],
+  ["198.51.100.0", 24],
+  ["203.0.113.0", 24],
+  ["224.0.0.0", 4],
+  ["240.0.0.0", 4],
+] as const) {
+  NON_PUBLIC_ADDRESSES.addSubnet(network, prefix, "ipv4");
+  NON_PUBLIC_ADDRESSES.addSubnet(`::ffff:${network}`, 96 + prefix, "ipv6");
+}
+for (const [network, prefix] of [
+  ["::", 128],
+  ["::1", 128],
+  ["2001:db8::", 32],
+  ["fc00::", 7],
+  ["fe80::", 10],
+  ["ff00::", 8],
+] as const) {
+  NON_PUBLIC_ADDRESSES.addSubnet(network, prefix, "ipv6");
+}
 
 function text(element: Element | null): string {
   return element?.textContent?.replace(/\s+/g, " ").trim() ?? "";
@@ -44,10 +93,14 @@ function throwIfAborted(signal?: AbortSignal) {
   signal?.throwIfAborted();
 }
 
-function timeoutSignal(message: string, signal?: AbortSignal): { signal: AbortSignal; cleanup: () => void } {
+function timeoutSignal(
+  message: string,
+  signal?: AbortSignal,
+  timeoutMs = TIMEOUT_MS,
+): { signal: AbortSignal; cleanup: () => void } {
   throwIfAborted(signal);
   const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(new Error(message)), TIMEOUT_MS);
+  const timeout = setTimeout(() => controller.abort(new Error(message)), timeoutMs);
   const onAbort = () => controller.abort(signal?.reason);
   signal?.addEventListener("abort", onAbort, { once: true });
   if (signal?.aborted) onAbort();
@@ -138,11 +191,71 @@ function validateHttpUrl(rawUrl: string): URL {
   return url;
 }
 
+function isNonPublicAddress(address: string): boolean {
+  const family = isIP(address);
+  return family !== 0 && NON_PUBLIC_ADDRESSES.check(address, family === 4 ? "ipv4" : "ipv6");
+}
+
+async function validatePublicHttpUrl(rawUrl: string): Promise<URL> {
+  const url = validateHttpUrl(rawUrl);
+  const hostname = url.hostname.replace(/^\[|\]$/g, "");
+  const family = isIP(hostname);
+  const addresses = family ? [hostname] : (await lookup(hostname, { all: true, verbatim: true })).map(({ address }) => address);
+
+  if (addresses.length === 0 || addresses.some(isNonPublicAddress)) {
+    throw new Error(`URL resolves to a non-public address: ${url.hostname}`);
+  }
+  return url;
+}
+
 async function readResponseText(response: Response, signal?: AbortSignal): Promise<string> {
   return new TextDecoder().decode(await readResponseBytes(response, signal));
 }
 
-async function readResponseBytes(response: Response, signal?: AbortSignal): Promise<Uint8Array> {
+function parseContentType(header: string | null): { contentType: string; mediaType: string; charset?: string } {
+  const contentType = header?.trim() || "application/octet-stream";
+  const [type = "", ...parameters] = contentType.split(";");
+  const mediaType = type.trim().toLowerCase() || "application/octet-stream";
+  const charsetParameter = parameters.find((parameter) => /^\s*charset\s*=/i.test(parameter));
+  const charset = charsetParameter?.replace(/^\s*charset\s*=\s*/i, "").trim().replace(/^(["'])(.*)\1$/, "$2");
+  return { contentType, mediaType, ...(charset ? { charset } : {}) };
+}
+
+function decodeText(bytes: Uint8Array, charset?: string): string {
+  try {
+    return new TextDecoder(charset || "utf-8").decode(bytes);
+  } catch {
+    return new TextDecoder().decode(bytes);
+  }
+}
+
+function isHtml(mediaType: string): boolean {
+  return mediaType === "text/html" || mediaType === "application/xhtml+xml";
+}
+
+function isMarkdown(mediaType: string): boolean {
+  return ["text/markdown", "text/x-markdown", "application/markdown", "application/x-markdown"].includes(mediaType);
+}
+
+function isText(mediaType: string): boolean {
+  if (mediaType.startsWith("text/")) return true;
+  if (mediaType.endsWith("+json") || mediaType.endsWith("+xml")) return true;
+  return [
+    "application/json",
+    "application/xml",
+    "application/javascript",
+    "application/x-javascript",
+    "application/yaml",
+    "application/x-yaml",
+    "application/toml",
+    "application/graphql",
+    "application/sql",
+    "application/x-www-form-urlencoded",
+    "image/svg+xml",
+  ].includes(mediaType);
+}
+
+async function readResponseBytes(response: Response, signal?: AbortSignal, maxBytes = MAX_BYTES): Promise<Uint8Array> {
   throwIfAborted(signal);
   const reader = response.body?.getReader();
   if (!reader) throw new Error("response body is not readable");
@@ -155,9 +268,9 @@ async function readResponseBytes(response: Response, signal?: AbortSignal): Prom
     if (done) break;
     if (!value) continue;
     received += value.byteLength;
-    if (received > MAX_BYTES) {
+    if (received > maxBytes) {
       await reader.cancel().catch(() => undefined);
-      throw new Error(`response exceeds ${MAX_BYTES} bytes`);
+      throw new Error(`response exceeds ${maxBytes} bytes`);
     }
     chunks.push(value);
   }
@@ -171,19 +284,20 @@ async function readResponseBytes(response: Response, signal?: AbortSignal): Prom
   return bytes;
 }
 
-async function fetchHtml(rawUrl: string, signal?: AbortSignal): Promise<{ url: string; html: string }> {
+async function fetchResource(rawUrl: string, signal?: AbortSignal, options: ReadUrlOptions = {}): Promise<FetchedResource> {
   throwIfAborted(signal);
   let currentUrl = validateHttpUrl(rawUrl).toString();
-  const timeout = timeoutSignal("fetch timeout", signal);
+  const timeout = timeoutSignal("fetch timeout", signal, options.timeoutMs);
 
   try {
     for (let redirect = 0; redirect <= MAX_REDIRECTS; redirect++) {
-      throwIfAborted(signal);
+      throwIfAborted(timeout.signal);
+      currentUrl = (await validatePublicHttpUrl(currentUrl)).toString();
       const response = await fetch(currentUrl, {
         redirect: "manual",
         signal: timeout.signal,
         headers: {
-          Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+          Accept: "text/html,text/markdown;q=0.9,text/*;q=0.8,*/*;q=0.7",
           "User-Agent": USER_AGENT,
         },
       });
@@ -193,7 +307,7 @@ async function fetchHtml(rawUrl: string, signal?: AbortSignal): Promise<{ url: s
         const location = response.headers.get("location");
         if (!location) throw new Error(`redirect without Location from ${currentUrl}`);
         currentUrl = validateHttpUrl(new URL(location, currentUrl).toString()).toString();
-        throwIfAborted(signal);
+        throwIfAborted(timeout.signal);
         continue;
       }
 
@@ -202,13 +316,12 @@ async function fetchHtml(rawUrl: string, signal?: AbortSignal): Promise<{ url: s
         throw new Error(`HTTP ${response.status} fetching ${currentUrl}`);
       }
 
-      const contentType = response.headers.get("content-type") ?? "";
-      if (!/\b(text\/html|application\/xhtml\+xml)\b/i.test(contentType)) {
-        await response.body?.cancel().catch(() => undefined);
-        throw new Error(`non-HTML content type: ${contentType || "unknown"}`);
-      }
-
-      return { url: currentUrl, html: await readResponseText(response, signal) };
+      const contentType = parseContentType(response.headers.get("content-type"));
+      return {
+        url: currentUrl,
+        ...contentType,
+        bytes: await readResponseBytes(response, timeout.signal, options.maxBytes),
+      };
     }
     throw new Error(`too many redirects fetching ${rawUrl}`);
   } finally {
@@ -216,32 +329,65 @@ async function fetchHtml(rawUrl: string, signal?: AbortSignal): Promise<{ url: s
   }
 }
 
-async function readUrl(url: string, signal?: AbortSignal): Promise<ReadUrlResult> {
+export async function readUrl(url: string, signal?: AbortSignal, options: ReadUrlOptions = {}): Promise<ReadUrlResult> {
   throwIfAborted(signal);
-  const fetched = await fetchHtml(url, signal);
+  const fetched = await fetchResource(url, signal, options);
   throwIfAborted(signal);
-  const dom = new JSDOM(fetched.html, { url: fetched.url });
-  const article = new Readability(dom.window.document).parse();
-  dom.window.close();
-  if (!article?.content) throw new Error("Readability could not extract article content");
 
-  throwIfAborted(signal);
-  const articleDom = new JSDOM(`<article>${article.content}</article>`);
-  for (const element of articleDom.window.document.querySelectorAll("script,style,iframe,noscript")) {
-    element.remove();
+  const metadata = {
+    url: fetched.url,
+    contentType: fetched.contentType,
+    bytes: fetched.bytes.byteLength,
+  };
+
+  if (isHtml(fetched.mediaType)) {
+    const html = decodeText(fetched.bytes, fetched.charset);
+    const dom = new JSDOM(html, { url: fetched.url });
+    const article = new Readability(dom.window.document).parse();
+    dom.window.close();
+    if (!article?.content) throw new Error("Readability could not extract article content");
+
+    throwIfAborted(signal);
+    const articleDom = new JSDOM(`<article>${article.content}</article>`);
+    for (const element of articleDom.window.document.querySelectorAll("script,style,iframe,noscript")) {
+      element.remove();
+    }
+    const turndown = new TurndownService({ codeBlockStyle: "fenced", headingStyle: "atx", bulletListMarker: "-" });
+    turndown.use(gfm);
+    const content = turndown.turndown(articleDom.window.document.body.innerHTML).trim();
+    articleDom.window.close();
+
+    return {
+      ...metadata,
+      contentFormat: "markdown",
+      content,
+      title: article.title || new URL(fetched.url).hostname,
+      excerpt: article.excerpt,
+      byline: article.byline,
+      length: article.length ?? article.textContent?.length ?? 0,
+    };
   }
-  const turndown = new TurndownService({ codeBlockStyle: "fenced", headingStyle: "atx", bulletListMarker: "-" });
-  turndown.use(gfm);
-  const markdown = turndown.turndown(articleDom.window.document.body.innerHTML).trim();
-  articleDom.window.close();
+
+  if (isMarkdown(fetched.mediaType)) {
+    return {
+      ...metadata,
+      contentFormat: "markdown",
+      content: decodeText(fetched.bytes, fetched.charset),
+    };
+  }
+
+  if (isText(fetched.mediaType)) {
+    return {
+      ...metadata,
+      contentFormat: "text",
+      content: decodeText(fetched.bytes, fetched.charset),
+    };
+  }
 
   return {
-    title: article.title || new URL(fetched.url).hostname,
-    url: fetched.url,
-    excerpt: article.excerpt,
-    byline: article.byline,
-    markdown,
-    length: article.length ?? article.textContent?.length ?? 0,
+    ...metadata,
+    contentFormat: "base64",
+    content: Buffer.from(fetched.bytes).toString("base64"),
   };
 }
 
@@ -268,8 +414,8 @@ export default function (pi: ExtensionAPI) {
   pi.registerTool({
     name: "web_fetch",
     label: "Web Fetch",
-    description: "Fetch a public HTML page, extract the main article with Readability, and return Markdown.",
-    promptSnippet: "Read a specific public URL and return cleaned Markdown article content.",
+    description: "Fetch a public URL. HTML is extracted with Readability and returned as Markdown; Markdown and text are passed through; other content is returned as base64. The result includes the source Content-Type.",
+    promptSnippet: "Fetch a public URL with content-type-aware handling; HTML becomes Markdown and other content is passed through.",
     promptGuidelines: ["Use web_fetch when the user provides a URL or when detailed source content is needed from a known URL."],
     parameters: {
       type: "object",

--- a/data/pi/extensions/web-tools/package.json
+++ b/data/pi/extensions/web-tools/package.json
@@ -6,6 +6,9 @@
   "pi": {
     "extensions": ["./index.ts"]
   },
+  "scripts": {
+    "test": "node --experimental-strip-types --test index.test.mjs"
+  },
   "dependencies": {
     "@joplin/turndown-plugin-gfm": "^1.0.67",
     "@mozilla/readability": "^0.6.0",

--- a/plans/pi-web-extension.md
+++ b/plans/pi-web-extension.md
@@ -41,7 +41,7 @@ Output:
 
 ### `web_fetch`
 
-Downloads one HTML page, extracts the main article, and returns Markdown.
+Downloads one URL and returns content according to its Content-Type. HTML is extracted and converted to Markdown, Markdown is passed through unchanged, other text is passed through, and binary content is base64-encoded.
 
 Input:
 
@@ -55,12 +55,15 @@ Output:
 
 ```json
 {
-  "title": "...",
   "url": "...",
+  "contentType": "text/html; charset=utf-8",
+  "contentFormat": "markdown",
+  "content": "...",
+  "bytes": 12345,
+  "title": "...",
   "excerpt": "...",
   "byline": "...",
-  "markdown": "...",
-  "length": 12345
+  "length": 12000
 }
 ```
 
@@ -78,7 +81,7 @@ web_search:
 DuckDuckGo HTML -> parse results -> title/url/snippet
 
 web_fetch:
-URL -> fetch HTML -> Readability -> Turndown -> Markdown
+URL -> inspect Content-Type -> HTML: Readability/Turndown; Markdown/text: pass through; binary: base64
 ```
 
 ## Safety and Reliability
@@ -89,7 +92,7 @@ Keep the implementation bounded:
 - cap response size
 - follow a small number of redirects
 - reject non-HTTP(S) schemes
-- only accept HTML-ish content types for `web_fetch`
+- handle HTML, Markdown, text, and binary responses explicitly and report the source Content-Type
 - honor cancellation signals
 
 ## Agent Usage Guidance


### PR DESCRIPTION
## Summary

- add content-type-aware handling for HTML, Markdown, text, and binary responses
- return a uniform content contract with source Content-Type metadata
- reject non-public destinations before requests and across redirects
- add automated coverage for MIME parsing, charsets, redirects, limits, cancellation, timeouts, and SSRF checks

## Validation

- `npm test --prefix data/pi/extensions/web-tools` (12 tests passed)
- `git diff --check`