### PR TITLE
feat: add pi subagent tooling

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -58,7 +58,8 @@ npm:
 
 commands:
   - "go install github.com/ryanfowler/gitlink@latest"
-  - "npm install --prefix data/pi/extensions/web-tools --quiet --ignore-scripts --no-fund --no-update-notifier"
+  - "go install github.com/ryanfowler/webtools@latest"
+  - 'webtools_bin="$(go env GOBIN)"; [ -n "$webtools_bin" ] || webtools_bin="$(go env GOPATH)/bin"; "$webtools_bin/webtools" install --force pi'
 
 rules:
   # alacritty
@@ -76,12 +77,16 @@ rules:
   # pi
   - src: "data/pi/extensions/rate-limits"
     dst: "$HOME/.pi/agent/extensions/rate-limits"
-  - src: "data/pi/extensions/web-tools"
-    dst: "$HOME/.pi/agent/extensions/web-tools"
+  - src: "data/pi/extensions/subagents"
+    dst: "$HOME/.pi/agent/extensions/subagents"
   - src: "data/pi/prompts/commit.md"
     dst: "$HOME/.pi/agent/prompts/commit.md"
+  - src: "data/pi/prompts/pir.md"
+    dst: "$HOME/.pi/agent/prompts/pir.md"
   - src: "data/pi/prompts/review.md"
     dst: "$HOME/.pi/agent/prompts/review.md"
+  - src: "data/pi/prompts/sub-review.md"
+    dst: "$HOME/.pi/agent/prompts/sub-review.md"
 
   # fish
   - src: "data/fish/config.fish"

--- a/data/pi/extensions/subagents/index.ts
+++ b/data/pi/extensions/subagents/index.ts
@@ -1,0 +1,580 @@
+import { realpath, stat } from "node:fs/promises";
+import { resolve } from "node:path";
+import { StringEnum, type Model, type Usage } from "@earendil-works/pi-ai";
+import {
+  createAgentSession,
+  DEFAULT_MAX_BYTES,
+  DEFAULT_MAX_LINES,
+  formatSize,
+  getAgentDir,
+  getMarkdownTheme,
+  keyHint,
+  ModelRuntime,
+  ProjectTrustStore,
+  SessionManager,
+  SettingsManager,
+  truncateHead,
+  type AgentSessionEvent,
+  type ExtensionAPI,
+  type ExtensionContext,
+} from "@earendil-works/pi-coding-agent";
+import { Container, Markdown, Spacer, Text } from "@earendil-works/pi-tui";
+import { Type } from "typebox";
+import { resolveSubagentProjectTrust } from "./trust.js";
+
+const EffortSchema = StringEnum(["off", "minimal", "low", "medium", "high", "xhigh", "max"] as const);
+const EXCLUDED_TOOLS = ["subagent", "subagent_spawn", "subagent_manage", "workflow", "ask_user", "ask_question"];
+const COLLAPSED_ACTIVITY_COUNT = 8;
+const MAX_TOOL_OUTPUT_CHARS = 1_200;
+
+type Activity =
+  | { type: "assistant"; text: string }
+  | {
+      type: "tool";
+      id: string;
+      name: string;
+      args: Record<string, unknown>;
+      status: "running" | "success" | "error";
+      output?: string;
+    };
+
+interface SubagentDetails {
+  status: "running" | "completed" | "error";
+  model?: string;
+  reasoningEffort?: string;
+  readOnly: boolean;
+  startedAt: number;
+  completedAt?: number;
+  stopReason?: string;
+  activities: Activity[];
+  usage?: Usage;
+}
+
+interface SubagentRenderState {
+  durationTimer?: ReturnType<typeof setInterval>;
+}
+
+function resultText(result: any): string {
+  if (!Array.isArray(result?.content)) return "";
+  return result.content
+    .filter((part: any) => part?.type === "text")
+    .map((part: any) => part.text)
+    .join("\n");
+}
+
+function previewToolOutput(result: any): string | undefined {
+  const text = resultText(result).trim();
+  if (!text) return undefined;
+  if (text.length <= MAX_TOOL_OUTPUT_CHARS) return text;
+  const half = Math.floor((MAX_TOOL_OUTPUT_CHARS - 40) / 2);
+  return `${text.slice(0, half)}\n… output omitted …\n${text.slice(-half)}`;
+}
+
+function snapshotDetails(details: SubagentDetails): SubagentDetails {
+  return {
+    ...details,
+    activities: details.activities.map((activity) =>
+      activity.type === "tool" ? { ...activity, args: { ...activity.args } } : { ...activity },
+    ),
+  };
+}
+
+function formatTokens(count: number): string {
+  if (count < 1_000) return String(count);
+  if (count < 10_000) return `${(count / 1_000).toFixed(1)}k`;
+  if (count < 1_000_000) return `${Math.round(count / 1_000)}k`;
+  return `${(count / 1_000_000).toFixed(1)}M`;
+}
+
+function formatUsage(usage: Usage | undefined): string {
+  if (!usage) return "";
+  const parts: string[] = [];
+  if (usage.input) parts.push(`↑${formatTokens(usage.input)}`);
+  if (usage.output) parts.push(`↓${formatTokens(usage.output)}`);
+  if (usage.cacheRead) parts.push(`R${formatTokens(usage.cacheRead)}`);
+  if (usage.cost.total) parts.push(`$${usage.cost.total.toFixed(4)}`);
+  return parts.join(" ");
+}
+
+function formatDuration(startedAt: number, completedAt = Date.now()): string {
+  const seconds = Math.max(0, Math.round((completedAt - startedAt) / 1_000));
+  if (seconds < 60) return `${seconds}s`;
+  return `${Math.floor(seconds / 60)}m ${seconds % 60}s`;
+}
+
+function compactText(text: string, maxLines: number, maxChars: number): string {
+  const lines = text.trim().split("\n");
+  let result = lines.slice(0, maxLines).join("\n");
+  if (result.length > maxChars) result = `${result.slice(0, Math.max(0, maxChars - 1))}…`;
+  if (lines.length > maxLines) result += `\n… ${lines.length - maxLines} more lines`;
+  return result;
+}
+
+function stringifyArgs(args: Record<string, unknown>): string {
+  try {
+    return JSON.stringify(args);
+  } catch {
+    return "{…}";
+  }
+}
+
+function displayToolArgs(name: string, input: unknown): Record<string, unknown> {
+  const args = input && typeof input === "object" ? input as Record<string, unknown> : {};
+  const pathArgs = { path: args.path, file_path: args.file_path };
+  switch (name) {
+    case "bash":
+      return { command: String(args.command ?? "").slice(0, 2_000) };
+    case "read":
+      return { ...pathArgs, offset: args.offset, limit: args.limit };
+    case "write":
+      return {
+        ...pathArgs,
+        lines: typeof args.content === "string" ? args.content.split("\n").length : undefined,
+      };
+    case "edit":
+      return {
+        ...pathArgs,
+        editCount: Array.isArray(args.edits) ? args.edits.length : undefined,
+      };
+    case "grep":
+      return { pattern: args.pattern, path: args.path, glob: args.glob, limit: args.limit };
+    case "find":
+      return { pattern: args.pattern, path: args.path, limit: args.limit };
+    case "ls":
+      return { path: args.path, limit: args.limit };
+    case "web_search":
+      return { query: String(args.query ?? "").slice(0, 1_000), limit: args.limit };
+    case "web_fetch":
+      return { url: String(args.url ?? "").slice(0, 2_000) };
+    default:
+      return { preview: stringifyArgs(args).slice(0, 2_000) };
+  }
+}
+
+function formatToolCall(
+  activity: Extract<Activity, { type: "tool" }>,
+  theme: any,
+  expanded: boolean,
+): string {
+  const { args, name } = activity;
+  const path = String(args.path ?? args.file_path ?? ".");
+  const limit = expanded ? 500 : 120;
+  const shorten = (text: string) => (text.length > limit ? `${text.slice(0, limit - 1)}…` : text);
+
+  switch (name) {
+    case "bash":
+      return theme.fg("muted", "$ ") + theme.fg("toolOutput", shorten(String(args.command ?? "…")));
+    case "read": {
+      let suffix = "";
+      if (args.offset !== undefined) suffix += `:${args.offset}`;
+      if (args.limit !== undefined) suffix += `+${args.limit}`;
+      return theme.fg("muted", "read ") + theme.fg("accent", `${path}${suffix}`);
+    }
+    case "write": {
+      const lines = typeof args.lines === "number" ? ` (${args.lines} lines)` : "";
+      return theme.fg("muted", "write ") + theme.fg("accent", path) + theme.fg("dim", lines);
+    }
+    case "edit": {
+      const count = typeof args.editCount === "number" ? ` (${args.editCount} changes)` : "";
+      return theme.fg("muted", "edit ") + theme.fg("accent", path) + theme.fg("dim", count);
+    }
+    case "grep":
+      return (
+        theme.fg("muted", "grep ") +
+        theme.fg("accent", `/${shorten(String(args.pattern ?? ""))}/`) +
+        theme.fg("dim", ` in ${path}`)
+      );
+    case "find":
+      return (
+        theme.fg("muted", "find ") +
+        theme.fg("accent", shorten(String(args.pattern ?? "*"))) +
+        theme.fg("dim", ` in ${path}`)
+      );
+    case "ls":
+      return theme.fg("muted", "ls ") + theme.fg("accent", path);
+    case "web_search":
+      return theme.fg("muted", "search ") + theme.fg("accent", shorten(String(args.query ?? "…")));
+    case "web_fetch":
+      return theme.fg("muted", "fetch ") + theme.fg("accent", shorten(String(args.url ?? "…")));
+    default:
+      return theme.fg("accent", name) + theme.fg("dim", ` ${shorten(String(args.preview ?? "{…}"))}`);
+  }
+}
+
+async function workingDirectory(input: string | undefined, ctx: ExtensionContext): Promise<string> {
+  const path = input?.startsWith("@") ? input.slice(1) : input;
+  const cwd = resolve(ctx.cwd, path || ".");
+  const info = await stat(cwd).catch(() => undefined);
+  if (!info?.isDirectory()) throw new Error(`Working directory does not exist: ${cwd}`);
+  return realpath(cwd);
+}
+
+function resolveModel(ctx: ExtensionContext, requested?: string) {
+  if (!requested) return ctx.model;
+  const slash = requested.indexOf("/");
+  if (slash > 0) {
+    const model = ctx.modelRegistry.find(requested.slice(0, slash), requested.slice(slash + 1));
+    if (!model) throw new Error(`Unknown model: ${requested}`);
+    return model;
+  }
+  if (ctx.model) {
+    const preferred = ctx.modelRegistry.find(ctx.model.provider, requested);
+    if (preferred) return preferred;
+  }
+  const matches = ctx.modelRegistry.getAll().filter((model) => model.id === requested);
+  if (matches.length === 1) return matches[0];
+  if (matches.length === 0) throw new Error(`Unknown model: ${requested}`);
+  throw new Error(`Ambiguous model id ${requested}; use provider/model`);
+}
+
+async function createChildModelRuntime(ctx: ExtensionContext, model: Model<any> | undefined): Promise<ModelRuntime> {
+  const runtime = await ModelRuntime.create();
+  if (!model) return runtime;
+
+  const provider = ctx.modelRegistry.getProvider(model.provider);
+  if (provider) runtime.registerNativeProvider(provider);
+
+  if (!ctx.modelRegistry.isUsingOAuth(model)) {
+    const auth = await ctx.modelRegistry.getProviderAuth(model.provider);
+    if (auth?.auth.apiKey) await runtime.setRuntimeApiKey(model.provider, auth.auth.apiKey);
+  }
+  return runtime;
+}
+
+function messageText(message: any): string {
+  if (typeof message?.content === "string") return message.content;
+  if (!Array.isArray(message?.content)) return "";
+  return message.content
+    .filter((part: any) => part?.type === "text")
+    .map((part: any) => part.text)
+    .join("");
+}
+
+function finalAssistant(session: any): any {
+  return [...session.messages].reverse().find((message: any) => message.role === "assistant");
+}
+
+function truncateOutput(text: string): string {
+  const result = truncateHead(text, { maxBytes: DEFAULT_MAX_BYTES, maxLines: DEFAULT_MAX_LINES });
+  if (!result.truncated) return result.content;
+  const notice = result.firstLineExceedsLimit
+    ? `[Output truncated: first line exceeds the ${formatSize(DEFAULT_MAX_BYTES)} limit.]`
+    : result.truncatedBy === "lines"
+      ? `[Output truncated: showing ${result.outputLines} of ${result.totalLines} lines.]`
+      : `[Output truncated: ${result.outputLines} lines shown (${formatSize(DEFAULT_MAX_BYTES)} limit).]`;
+  return result.content ? `${result.content}\n\n${notice}` : notice;
+}
+
+function aggregateUsage(session: any): Usage | undefined {
+  const usages: Usage[] = [];
+  for (const entry of session.sessionManager.getEntries()) {
+    if (entry.type === "message" && entry.message?.usage) usages.push(entry.message.usage);
+    else if ((entry.type === "compaction" || entry.type === "branch_summary") && entry.usage) usages.push(entry.usage);
+  }
+  if (!usages.length) return undefined;
+  const hasReasoning = usages.some((usage) => usage.reasoning !== undefined);
+  const hasCacheWrite1h = usages.some((usage) => usage.cacheWrite1h !== undefined);
+  return {
+    input: usages.reduce((total, usage) => total + usage.input, 0),
+    output: usages.reduce((total, usage) => total + usage.output, 0),
+    cacheRead: usages.reduce((total, usage) => total + usage.cacheRead, 0),
+    cacheWrite: usages.reduce((total, usage) => total + usage.cacheWrite, 0),
+    totalTokens: usages.reduce((total, usage) => total + usage.totalTokens, 0),
+    reasoning: hasReasoning ? usages.reduce((total, usage) => total + (usage.reasoning ?? 0), 0) : undefined,
+    cacheWrite1h: hasCacheWrite1h ? usages.reduce((total, usage) => total + (usage.cacheWrite1h ?? 0), 0) : undefined,
+    cost: {
+      input: usages.reduce((total, usage) => total + usage.cost.input, 0),
+      output: usages.reduce((total, usage) => total + usage.cost.output, 0),
+      cacheRead: usages.reduce((total, usage) => total + usage.cost.cacheRead, 0),
+      cacheWrite: usages.reduce((total, usage) => total + usage.cost.cacheWrite, 0),
+      total: usages.reduce((total, usage) => total + usage.cost.total, 0),
+    },
+  };
+}
+
+export default function (pi: ExtensionAPI) {
+  pi.registerTool({
+    name: "subagent",
+    label: "Subagent",
+    description: "Run one isolated pi agent and wait for its result. Multiple sibling calls can run in parallel. All subagents can search and fetch the web. Inspection mode (`read_only`) removes edit/write tools, but bash is not sandboxed, so prompts must restrict it to inspection commands.",
+    promptSnippet: "Run an isolated pi agent synchronously",
+    parameters: Type.Object({
+      prompt: Type.String({ description: "Complete task for the child agent" }),
+      working_dir: Type.Optional(Type.String({ description: "Working directory, relative to the parent by default" })),
+      model: Type.Optional(Type.String({ description: "provider/model or an unambiguous model id" })),
+      reasoning_effort: Type.Optional(EffortSchema),
+      read_only: Type.Optional(Type.Boolean({ description: "Enable inspection mode: remove edit/write tools. Web search/fetch and bash remain available; bash is not sandboxed." })),
+    }),
+    async execute(_id, params, signal, onUpdate, ctx) {
+      if (signal?.aborted) throw new Error("Subagent aborted");
+      const cwd = await workingDirectory(params.working_dir, ctx);
+      const settingsManager = SettingsManager.create(cwd, getAgentDir());
+      const parentCwd = await realpath(resolve(ctx.cwd));
+      const trustStore = new ProjectTrustStore(getAgentDir());
+      const trusted = resolveSubagentProjectTrust({
+        parentCwd,
+        cwd,
+        parentTrusted: ctx.isProjectTrusted(),
+        getTrustEntry: (directory) => trustStore.getEntry(directory),
+      });
+      settingsManager.setProjectTrusted(trusted);
+
+      const model = resolveModel(ctx, params.model);
+      const modelRuntime = await createChildModelRuntime(ctx, model);
+      const { session } = await createAgentSession({
+        cwd,
+        model,
+        modelRuntime,
+        thinkingLevel: params.reasoning_effort ?? ctx.thinkingLevel,
+        tools: params.read_only
+          ? ["read", "bash", "web_search", "web_fetch"]
+          : ["read", "bash", "edit", "write", "web_search", "web_fetch"],
+        excludeTools: EXCLUDED_TOOLS,
+        sessionManager: SessionManager.inMemory(cwd),
+        settingsManager,
+      });
+
+      const details: SubagentDetails = {
+        status: "running",
+        model: session.model ? `${session.model.provider}/${session.model.id}` : undefined,
+        reasoningEffort: params.reasoning_effort ?? ctx.thinkingLevel,
+        readOnly: params.read_only ?? false,
+        startedAt: Date.now(),
+        activities: [],
+      };
+      const toolActivities = new Map<string, Extract<Activity, { type: "tool" }>>();
+      let currentAssistant: Extract<Activity, { type: "assistant" }> | undefined;
+      let streamedText = "";
+      let unsubscribe = () => {};
+      let updateTimer: ReturnType<typeof setTimeout> | undefined;
+      let pendingUpdate: string | undefined;
+      const abort = () => { void session.abort(); };
+      const flushUpdate = () => {
+        if (updateTimer) clearTimeout(updateTimer);
+        updateTimer = undefined;
+        if (pendingUpdate === undefined) return;
+        const text = pendingUpdate;
+        pendingUpdate = undefined;
+        onUpdate?.({
+          content: [{ type: "text", text }],
+          details: snapshotDetails(details),
+        });
+      };
+      const emitUpdate = (text: string, immediate = false) => {
+        if (!onUpdate) return;
+        pendingUpdate = text;
+        if (immediate) {
+          flushUpdate();
+        } else if (!updateTimer) {
+          updateTimer = setTimeout(flushUpdate, 80);
+        }
+      };
+
+      try {
+        unsubscribe = session.subscribe((event: AgentSessionEvent) => {
+          if (event.type === "message_start" && event.message.role === "assistant") {
+            currentAssistant = { type: "assistant", text: "" };
+            details.activities.push(currentAssistant);
+          } else if (event.type === "message_update" && event.assistantMessageEvent.type === "text_delta") {
+            if (!currentAssistant) {
+              currentAssistant = { type: "assistant", text: "" };
+              details.activities.push(currentAssistant);
+            }
+            currentAssistant.text += event.assistantMessageEvent.delta;
+            streamedText += event.assistantMessageEvent.delta;
+            emitUpdate(currentAssistant.text || "Subagent is thinking…");
+          } else if (event.type === "message_end" && event.message.role === "assistant") {
+            const text = messageText(event.message);
+            details.usage = aggregateUsage(session);
+            if (text) {
+              if (!currentAssistant) {
+                currentAssistant = { type: "assistant", text };
+                details.activities.push(currentAssistant);
+              } else {
+                currentAssistant.text = text;
+              }
+            }
+            if (currentAssistant && !currentAssistant.text) details.activities.pop();
+            currentAssistant = undefined;
+            if (text) emitUpdate(text, true);
+          } else if (event.type === "tool_execution_start") {
+            const activity: Extract<Activity, { type: "tool" }> = {
+              type: "tool",
+              id: event.toolCallId,
+              name: event.toolName,
+              args: displayToolArgs(event.toolName, event.args),
+              status: "running",
+            };
+            toolActivities.set(event.toolCallId, activity);
+            details.activities.push(activity);
+            emitUpdate(`Running ${event.toolName}…`, true);
+          } else if (event.type === "tool_execution_update") {
+            const activity = toolActivities.get(event.toolCallId);
+            if (activity) {
+              activity.output = previewToolOutput(event.partialResult);
+              emitUpdate(`Running ${event.toolName}…`);
+            }
+          } else if (event.type === "tool_execution_end") {
+            const activity = toolActivities.get(event.toolCallId);
+            if (activity) {
+              activity.status = event.isError ? "error" : "success";
+              activity.output = previewToolOutput(event.result);
+              emitUpdate(`${event.toolName} ${event.isError ? "failed" : "completed"}`, true);
+            }
+          }
+        });
+        signal?.addEventListener("abort", abort, { once: true });
+        if (signal?.aborted) {
+          await session.abort();
+          throw new Error("Subagent aborted");
+        }
+
+        emitUpdate("Starting subagent…", true);
+        await session.prompt(params.prompt);
+        const assistant = finalAssistant(session);
+        const failed =
+          assistant?.stopReason === "error" ||
+          assistant?.stopReason === "aborted" ||
+          assistant?.stopReason === "length";
+        if (failed) {
+          const errorMessage = assistant.errorMessage || (assistant.stopReason === "length"
+            ? "Subagent reached its output limit before completing the task"
+            : `Subagent ${assistant.stopReason}`);
+          const usage = aggregateUsage(session);
+          details.status = "error";
+          details.stopReason = assistant.stopReason;
+          details.completedAt = Date.now();
+          details.usage = usage;
+          emitUpdate(errorMessage, true);
+          return {
+            content: [{ type: "text", text: errorMessage }],
+            details: snapshotDetails(details),
+            usage,
+          };
+        }
+
+        const usage = aggregateUsage(session);
+        const output = messageText(assistant) || streamedText || "(no output)";
+        details.status = "completed";
+        details.stopReason = assistant?.stopReason;
+        details.completedAt = Date.now();
+        details.usage = usage;
+        return {
+          content: [{ type: "text", text: truncateOutput(output) }],
+          details: snapshotDetails(details),
+          usage,
+        };
+      } finally {
+        if (updateTimer) clearTimeout(updateTimer);
+        signal?.removeEventListener("abort", abort);
+        unsubscribe();
+        session.dispose();
+      }
+    },
+
+    renderCall(args, theme, context) {
+      const mode = args.read_only ? "inspection" : "write-enabled";
+      const model = args.model ? ` · ${args.model}` : "";
+      const effort = args.reasoning_effort ? ` · ${args.reasoning_effort}` : "";
+      let text =
+        theme.fg("toolTitle", theme.bold("subagent ")) +
+        theme.fg(args.read_only ? "success" : "warning", mode) +
+        theme.fg("muted", `${model}${effort}`);
+      if (args.working_dir) text += `\n${theme.fg("muted", "in ")}${theme.fg("accent", args.working_dir)}`;
+      const rawPrompt = typeof args.prompt === "string" ? args.prompt : "…";
+      const prompt = context.expanded ? rawPrompt : compactText(rawPrompt, 2, 180);
+      text += `\n${theme.fg("dim", prompt)}`;
+      return new Text(text, 0, 0);
+    },
+
+    renderResult(result, { expanded, isPartial }, theme, context) {
+      const state = context.state as SubagentRenderState;
+      if (isPartial && !context.isError && !state.durationTimer) {
+        state.durationTimer = setInterval(context.invalidate, 1_000);
+      }
+      if ((!isPartial || context.isError) && state.durationTimer) {
+        clearInterval(state.durationTimer);
+        state.durationTimer = undefined;
+      }
+
+      const details = result.details as SubagentDetails | undefined;
+      if (!details || !Array.isArray(details.activities)) {
+        const content = result.content[0];
+        return new Text(content?.type === "text" ? content.text : "(no output)", 0, 0);
+      }
+
+      const running = isPartial || details.status === "running";
+      const failed = details.status === "error";
+      const icon = running
+        ? theme.fg("warning", "●")
+        : failed
+          ? theme.fg("error", "✗")
+          : theme.fg("success", "✓");
+      const toolCount = details.activities.filter((activity) => activity.type === "tool").length;
+      const duration = formatDuration(details.startedAt, details.completedAt);
+      const metadata = [
+        details.model,
+        details.reasoningEffort,
+        details.readOnly ? "inspection" : undefined,
+        `${toolCount} tool${toolCount === 1 ? "" : "s"}`,
+        duration,
+      ].filter(Boolean);
+      const container = context.lastComponent instanceof Container
+        ? context.lastComponent
+        : new Container();
+      container.clear();
+      container.addChild(
+        new Text(
+          `${icon} ${theme.fg("toolTitle", theme.bold(running ? "Subagent running" : failed ? "Subagent failed" : "Subagent complete"))}` +
+            theme.fg("muted", ` · ${metadata.join(" · ")}`),
+          0,
+          0,
+        ),
+      );
+
+      const activities = expanded ? details.activities : details.activities.slice(-COLLAPSED_ACTIVITY_COUNT);
+      const skipped = details.activities.length - activities.length;
+      if (activities.length === 0) {
+        container.addChild(new Text(theme.fg("muted", "Waiting for the first response…"), 0, 0));
+      } else {
+        container.addChild(new Spacer(1));
+        if (skipped > 0) {
+          container.addChild(new Text(theme.fg("muted", `… ${skipped} earlier activities`), 0, 0));
+        }
+        for (const activity of activities) {
+          if (activity.type === "assistant") {
+            if (!activity.text.trim()) continue;
+            const text = expanded ? activity.text.trim() : compactText(activity.text, 3, 500);
+            if (expanded) container.addChild(new Markdown(text, 0, 0, getMarkdownTheme()));
+            else container.addChild(new Text(theme.fg("toolOutput", text), 0, 0));
+            continue;
+          }
+
+          const statusIcon =
+            activity.status === "running"
+              ? theme.fg("warning", "●")
+              : activity.status === "error"
+                ? theme.fg("error", "✗")
+                : theme.fg("success", "✓");
+          container.addChild(
+            new Text(`${statusIcon} ${formatToolCall(activity, theme, expanded)}`, 0, 0),
+          );
+          if (expanded && activity.output) {
+            container.addChild(new Text(theme.fg("dim", compactText(activity.output, 12, MAX_TOOL_OUTPUT_CHARS)), 1, 0));
+          } else if (activity.status === "error" && activity.output) {
+            container.addChild(new Text(theme.fg("error", compactText(activity.output, 2, 240)), 1, 0));
+          }
+        }
+      }
+
+      const usage = formatUsage(details.usage);
+      const hint = !expanded && details.activities.length > 0 ? keyHint("app.tools.expand", "to expand") : "";
+      const footer = [usage, hint].filter(Boolean).join(" · ");
+      if (footer) {
+        container.addChild(new Spacer(1));
+        container.addChild(new Text(theme.fg("dim", footer), 0, 0));
+      }
+      return container;
+    },
+  });
+}

--- a/data/pi/extensions/subagents/trust.js
+++ b/data/pi/extensions/subagents/trust.js
@@ -1,0 +1,36 @@
+import { isAbsolute, relative, sep } from "node:path";
+
+/**
+ * Return true when candidate is root or one of its descendants.
+ * Both paths must be canonical absolute paths.
+ *
+ * @param {string} root
+ * @param {string} candidate
+ */
+export function isWithinDirectory(root, candidate) {
+  const path = relative(root, candidate);
+  return path === "" || (path !== ".." && !path.startsWith(`..${sep}`) && !isAbsolute(path));
+}
+
+/**
+ * Resolve trust for a subagent working directory.
+ * The active parent-session decision overrides saved decisions at or above the
+ * parent. A more-specific saved decision applies to a nested project.
+ *
+ * @param {{
+ *   parentCwd: string,
+ *   cwd: string,
+ *   parentTrusted: boolean,
+ *   getTrustEntry: (cwd: string) => { path: string, decision: boolean } | null,
+ * }} options
+ */
+export function resolveSubagentProjectTrust({ parentCwd, cwd, parentTrusted, getTrustEntry }) {
+  const entry = getTrustEntry(cwd);
+  if (!isWithinDirectory(parentCwd, cwd)) return entry?.decision === true;
+
+  const hasNestedDecision =
+    entry !== null &&
+    entry.path !== parentCwd &&
+    isWithinDirectory(parentCwd, entry.path);
+  return hasNestedDecision ? entry.decision : parentTrusted;
+}

--- a/data/pi/extensions/subagents/trust.test.mjs
+++ b/data/pi/extensions/subagents/trust.test.mjs
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { isWithinDirectory, resolveSubagentProjectTrust } from "./trust.js";
+
+const parentCwd = "/work/project";
+
+function resolve(cwd, parentTrusted, entry = null) {
+  return resolveSubagentProjectTrust({
+    parentCwd,
+    cwd,
+    parentTrusted,
+    getTrustEntry: () => entry,
+  });
+}
+
+test("recognizes only the root and its descendants", () => {
+  assert.equal(isWithinDirectory(parentCwd, parentCwd), true);
+  assert.equal(isWithinDirectory(parentCwd, "/work/project/src"), true);
+  assert.equal(isWithinDirectory(parentCwd, "/work/project-other"), false);
+  assert.equal(isWithinDirectory(parentCwd, "/work"), false);
+});
+
+test("inherits the active session decision without a nested decision", () => {
+  assert.equal(resolve(parentCwd, true), true);
+  assert.equal(resolve("/work/project/src", false), false);
+  assert.equal(resolve("/work/project/src", false, { path: parentCwd, decision: true }), false);
+  assert.equal(resolve("/work/project/src", true, { path: "/work", decision: false }), true);
+});
+
+test("honors a more-specific nested trust decision", () => {
+  const nested = "/work/project/vendor/repository";
+  assert.equal(resolve(`${nested}/src`, true, { path: nested, decision: false }), false);
+  assert.equal(resolve(`${nested}/src`, false, { path: nested, decision: true }), true);
+});
+
+test("uses only persisted trust for an unrelated directory", () => {
+  const external = "/other/project";
+  assert.equal(resolve(external, true), false);
+  assert.equal(resolve(external, false, { path: external, decision: true }), true);
+  assert.equal(resolve(external, true, { path: external, decision: false }), false);
+});

--- a/data/pi/prompts/commit.md
+++ b/data/pi/prompts/commit.md
@@ -18,10 +18,12 @@ Workflow:
    - Otherwise use `main` if it exists
    - Otherwise use `master` if it exists
 
-3. Review the changes before committing:
-   - Understand the intent of the diff
+3. Review and validate the changes before committing:
+   - Inspect the diff directly and understand its intent
+   - Do not call a subagent or perform a full review workflow
    - Watch for secrets, accidental debug code, generated junk, or unrelated changes
-   - If changes look unsafe or unrelated, stop and ask before committing
+   - Run the repository's applicable programmatic checks, such as tests, linters, type checks, format checks, or builds
+   - If changes look unsafe or unrelated, or a relevant check fails, stop and ask before committing
 
 4. Create or confirm the working branch before staging:
    - If the current branch is the primary branch, create a new appropriately named branch before staging or committing

--- a/data/pi/prompts/pir.md
+++ b/data/pi/prompts/pir.md
@@ -1,0 +1,15 @@
+---
+description: Plan, implement, and iteratively review a task with subagents
+argument-hint: "<implementation task>"
+---
+Complete the following implementation task end-to-end:
+
+$ARGUMENTS
+
+Use this workflow without stopping between phases:
+
+1. Call the `subagent` tool with `read_only: true` and `reasoning_effort: "high"` to create a concrete implementation plan. Tell it to inspect the repository thoroughly, use only read-only shell commands, and return a concise ordered plan without modifying files.
+2. Implement the task yourself according to that plan. Modify the working tree, add or update tests, and run the relevant checks. Do not merely describe the implementation.
+3. Call another `subagent` against the live checkout with `read_only: true` and `reasoning_effort: "high"`. Include the original task and plan in its prompt. Tell it to inspect staged, unstaged, and untracked changes using only read-only commands such as `git status`, `git diff`, and `git ls-files`; use `web_search` and `web_fetch` when external documentation or current information would help verify a finding; review correctness, resource handling, concurrency, performance, compatibility, security, test coverage, complexity, and completeness; and return only actionable findings or exactly `No actionable findings.`
+4. If the reviewer reports actionable findings, resolve every valid finding, update and run tests as needed, then repeat step 3. Stop after no actionable findings remain or after five total reviews.
+5. Summarize the completed implementation, tests run, and any findings intentionally left unresolved.

--- a/data/pi/prompts/sub-review.md
+++ b/data/pi/prompts/sub-review.md
@@ -1,0 +1,16 @@
+---
+description: Iteratively review and fix working-tree changes with fresh subagents
+argument-hint: "[focus]"
+---
+Review and improve the current unstaged and untracked changes. Optional focus from the user: ${ARGUMENTS:-none}
+
+Use this workflow without stopping between review passes:
+
+1. Call the `subagent` tool with `read_only: true` and `reasoning_effort: "high"`. Give it the prompt `/review ${ARGUMENTS:-} Use only read-only inspection commands and do not modify files.` This runs the existing `/review` prompt in a fresh isolated session.
+2. Evaluate every finding against the working tree. Ignore speculative or incorrect findings. If the subagent reports no findings, stop the review loop.
+3. In the main session, resolve every valid actionable finding. Add or update tests when needed, and run the relevant validation after making changes.
+4. Call a new subagent with the same settings and `/review` prompt to review the updated working tree. Do not reuse a prior subagent session.
+5. Repeat steps 2 through 4 until a review reports no findings or five total subagent review passes have completed. Never exceed five review passes.
+6. Summarize the fixes, validation results, number of review passes, and any findings intentionally left unresolved. If the fifth review still reports valid findings, do not start another review pass; report the remaining findings clearly.
+
+Do not ask the user to continue between passes unless a finding requires information or a decision that cannot be inferred safely.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "check": "node --check src/main.js",
+    "check": "node --check src/main.js && node --check data/pi/extensions/subagents/index.ts && node --test data/pi/extensions/subagents/trust.test.mjs",
     "install-dotfiles": "node src/main.js"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- add an isolated pi subagent extension with trust handling and activity rendering
- add iterative implementation and review prompt workflows
- install web tools through the Go CLI and link the new pi configuration

## Validation
- `npm run check`
- parsed `config.yaml` with the `yaml` package
- `git diff --cached --check`
