### PR TITLE
fix: preserve subagent expanded scroll position

### DIFF
--- a/data/pi/extensions/subagents/index.ts
+++ b/data/pi/extensions/subagents/index.ts
@@ -21,6 +21,7 @@ import {
 import { Container, Markdown, Spacer, Text } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
 import { resolveSubagentProjectTrust } from "./trust.js";
+import { ExpandedUpdateGate } from "./update-gate.js";
 
 const ModelSchema = StringEnum(["gpt-5.6-luna", "gpt-5.6-sol"] as const, {
   description: "Select Luna for straightforward, bounded tasks. Select Sol for complex, ambiguous, broad, or high-risk tasks.",
@@ -58,6 +59,7 @@ interface SubagentDetails {
 
 interface SubagentRenderState {
   durationTimer?: ReturnType<typeof setInterval>;
+  expandedDuration?: string;
 }
 
 function resultText(result: any): string {
@@ -287,6 +289,8 @@ function aggregateUsage(session: any): Usage | undefined {
 }
 
 export default function (pi: ExtensionAPI) {
+  const updateGate = new ExpandedUpdateGate();
+
   pi.registerTool({
     name: "subagent",
     label: "Subagent",
@@ -299,7 +303,7 @@ export default function (pi: ExtensionAPI) {
       reasoning_effort: EffortSchema,
       read_only: Type.Optional(Type.Boolean({ description: "Enable inspection mode: remove edit/write tools. Web search/fetch and bash remain available; bash is not sandboxed." })),
     }),
-    async execute(_id, params, signal, onUpdate, ctx) {
+    async execute(toolCallId, params, signal, onUpdate, ctx) {
       if (signal?.aborted) throw new Error("Subagent aborted");
       const cwd = await workingDirectory(params.working_dir, ctx);
       const settingsManager = SettingsManager.create(cwd, getAgentDir());
@@ -349,13 +353,17 @@ export default function (pi: ExtensionAPI) {
         if (pendingUpdate === undefined) return;
         const text = pendingUpdate;
         pendingUpdate = undefined;
+        // Updating content below the terminal viewport forces the terminal back
+        // to the bottom. Pause partial updates while the user reads the expanded
+        // output. The final result still renders when execution completes.
+        if (updateGate.isPaused(toolCallId)) return;
         onUpdate?.({
           content: [{ type: "text", text }],
           details: snapshotDetails(details),
         });
       };
       const emitUpdate = (text: string, immediate = false) => {
-        if (!onUpdate) return;
+        if (!onUpdate || updateGate.isPaused(toolCallId)) return;
         pendingUpdate = text;
         if (immediate) {
           flushUpdate();
@@ -460,6 +468,7 @@ export default function (pi: ExtensionAPI) {
         };
       } finally {
         if (updateTimer) clearTimeout(updateTimer);
+        updateGate.delete(toolCallId);
         signal?.removeEventListener("abort", abort);
         unsubscribe();
         session.dispose();
@@ -483,13 +492,22 @@ export default function (pi: ExtensionAPI) {
 
     renderResult(result, { expanded, isPartial }, theme, context) {
       const state = context.state as SubagentRenderState;
-      if (isPartial && !context.isError && !state.durationTimer) {
+      updateGate.sync(context.toolCallId, {
+        expanded,
+        isPartial,
+        isError: context.isError,
+      });
+      // A changing line above the terminal viewport makes the TUI redraw the full
+      // screen. Keep the expanded header stable so users can scroll through a
+      // running subagent without each duration tick returning them to the bottom.
+      if (isPartial && !context.isError && !expanded && !state.durationTimer) {
         state.durationTimer = setInterval(context.invalidate, 1_000);
       }
-      if ((!isPartial || context.isError) && state.durationTimer) {
+      if ((!isPartial || context.isError || expanded) && state.durationTimer) {
         clearInterval(state.durationTimer);
         state.durationTimer = undefined;
       }
+      if (!expanded) state.expandedDuration = undefined;
 
       const details = result.details as SubagentDetails | undefined;
       if (!details || !Array.isArray(details.activities)) {
@@ -505,7 +523,9 @@ export default function (pi: ExtensionAPI) {
           ? theme.fg("error", "✗")
           : theme.fg("success", "✓");
       const toolCount = details.activities.filter((activity) => activity.type === "tool").length;
-      const duration = formatDuration(details.startedAt, details.completedAt);
+      const duration = running && expanded
+        ? state.expandedDuration ??= formatDuration(details.startedAt, details.completedAt)
+        : formatDuration(details.startedAt, details.completedAt);
       const metadata = [
         details.model,
         details.reasoningEffort,

--- a/data/pi/extensions/subagents/update-gate.js
+++ b/data/pi/extensions/subagents/update-gate.js
@@ -1,0 +1,16 @@
+export class ExpandedUpdateGate {
+  #toolCallIds = new Set();
+
+  sync(toolCallId, { expanded, isPartial, isError }) {
+    if (expanded && isPartial && !isError) this.#toolCallIds.add(toolCallId);
+    else this.#toolCallIds.delete(toolCallId);
+  }
+
+  isPaused(toolCallId) {
+    return this.#toolCallIds.has(toolCallId);
+  }
+
+  delete(toolCallId) {
+    this.#toolCallIds.delete(toolCallId);
+  }
+}

--- a/data/pi/extensions/subagents/update-gate.test.mjs
+++ b/data/pi/extensions/subagents/update-gate.test.mjs
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { ExpandedUpdateGate } from "./update-gate.js";
+
+test("pauses partial updates only while the running result is expanded", () => {
+  const gate = new ExpandedUpdateGate();
+
+  gate.sync("call-1", { expanded: true, isPartial: true, isError: false });
+  assert.equal(gate.isPaused("call-1"), true);
+
+  gate.sync("call-1", { expanded: false, isPartial: true, isError: false });
+  assert.equal(gate.isPaused("call-1"), false);
+});
+
+test("allows final and error results while expanded", () => {
+  const gate = new ExpandedUpdateGate();
+
+  gate.sync("final", { expanded: true, isPartial: true, isError: false });
+  gate.sync("final", { expanded: true, isPartial: false, isError: false });
+  assert.equal(gate.isPaused("final"), false);
+
+  gate.sync("error", { expanded: true, isPartial: true, isError: false });
+  gate.sync("error", { expanded: true, isPartial: true, isError: true });
+  assert.equal(gate.isPaused("error"), false);
+});
+
+test("tracks concurrent tool calls independently and supports cleanup", () => {
+  const gate = new ExpandedUpdateGate();
+
+  gate.sync("expanded", { expanded: true, isPartial: true, isError: false });
+  gate.sync("collapsed", { expanded: false, isPartial: true, isError: false });
+  assert.equal(gate.isPaused("expanded"), true);
+  assert.equal(gate.isPaused("collapsed"), false);
+
+  gate.delete("expanded");
+  assert.equal(gate.isPaused("expanded"), false);
+});

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "check": "node --check src/main.js && node --check data/pi/extensions/subagents/index.ts && node --test data/pi/extensions/subagents/trust.test.mjs",
+    "check": "node --check src/main.js && node --check data/pi/extensions/subagents/index.ts && node --test data/pi/extensions/subagents/*.test.mjs",
     "install-dotfiles": "node src/main.js"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- pause partial subagent updates while expanded so terminal redraws do not force the viewport to the bottom
- freeze the running duration in expanded output
- add update-gate coverage for expansion, completion, errors, and concurrent calls

## Validation
- `npm run check`
- `git diff --check`