### PR TITLE
chore: remove neofetch from Homebrew packages

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -22,7 +22,6 @@ homebrew:
     - lua-language-server
     - marksman
     - ncurses
-    - neofetch
     - neovim
     - node
     - parallel


### PR DESCRIPTION
## Summary
- remove the obsolete neofetch formula from the Homebrew package list

## Validation
- npm run check